### PR TITLE
Allow specifying requiredShippingContactFields in Apple Pay

### DIFF
--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -92,8 +92,7 @@ class ApplePay extends Emitter {
       merchantCapabilities: this.config.merchantCapabilities,
       requiredBillingContactFields: ['postalAddress'],
       requiredShippingContactFields: this.config.requiredShippingContactFields,
-      shippingMethods: this.config.shippingMethods,
-      
+
       total: this.totalLineItem
     });
 
@@ -207,9 +206,6 @@ class ApplePay extends Emitter {
       this.config.supportedNetworks = info.supportedNetworks || [];
 
       this.config.requiredShippingContactFields = options.requiredShippingContactFields || [];
-      this.config.shippingMethods = options.shippingMethods || [];
-      this.config.freeShippingMethod = options.freeShippingMethod || [];
-      this.config.internationalShippingMethod = options.internationalShippingMethod || [];
       this.emit('ready');
     }
   }
@@ -311,39 +307,10 @@ class ApplePay extends Emitter {
   onShippingContactSelected (event) {
     const status = this.session.STATUS_SUCCESS;
 
-    var myShippingContact = event.shippingContact;
+    this.emit('shippingContactSelected', event);
 
-    var newTotal = this.finalTotalLineItem;
     var newShippingMethods = [];
     
-    var periodLength = this.config.pricing.items.plan.period.length;
-    
-    var internationalShippingCost = parseFloat(this.config.pricing.price.addons.shipping);
-
-    var basePrice = this.config.pricing.items.plan.price.USD.amount;
-
-    var internationalShipping = {
-      label: "International Shipping", 
-      amount: internationalShippingCost
-    }
-
-    var freeShipping = {
-      label: "Free Shipping in USA", 
-      amount: 0.00
-    }
-
-    if (myShippingContact.countryCode != 'us') {
-      this.config.total = basePrice + internationalShippingCost;
-      this.config.shippingItems = [internationalShipping];
-    }
-    else {
-      // newShippingMethods = [this.config.freeShippingMethod];
-      this.config.total = basePrice;
-      this.config.shippingItems = [freeShipping];
-    }
-
-    // console.log(this.lineItems);
-
     this.session.completeShippingContactSelection(status, newShippingMethods, this.finalTotalLineItem, this.lineItems);
   }
 

--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -110,7 +110,7 @@ class ApplePay extends Emitter {
    */
   get lineItems () {
     // Clone configured line items
-    return [].concat(this.config.lineItems).concat(this.config.shippingItems);
+    return [].concat(this.config.lineItems);
   }
 
   /**
@@ -165,9 +165,6 @@ class ApplePay extends Emitter {
     // Initialize with no line items
     this.config.lineItems = [];
 
-    // Initialize with no shipping items
-    this.config.shippingItems = [];
-
     if ('recurly' in options) this.recurly = options.recurly;
     else return this.initError = this.error('apple-pay-factory-only');
 
@@ -204,7 +201,7 @@ class ApplePay extends Emitter {
       this.config.merchantCapabilities = info.merchantCapabilities || [];
       this.config.supportedNetworks = info.supportedNetworks || [];
       this.config.requiredShippingContactFields = options.requiredShippingContactFields || [];
-      
+
       this.emit('ready');
     }
   }
@@ -306,7 +303,7 @@ class ApplePay extends Emitter {
   onShippingContactSelected (event) {
     const status = this.session.STATUS_SUCCESS;
     const newShippingMethods = [];
-
+console.log(this.lineItems);
     this.emit('shippingContactSelected', event);
     
     this.session.completeShippingContactSelection(status, newShippingMethods, this.finalTotalLineItem, this.lineItems);

--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -91,6 +91,7 @@ class ApplePay extends Emitter {
       supportedNetworks: this.config.supportedNetworks,
       merchantCapabilities: this.config.merchantCapabilities,
       requiredBillingContactFields: ['postalAddress'],
+      requiredShippingContactFields: this.config.shippingContactFields,
       total: this.totalLineItem
     });
 
@@ -200,6 +201,7 @@ class ApplePay extends Emitter {
       this.config.merchantCapabilities = info.merchantCapabilities || [];
       this.config.supportedNetworks = info.supportedNetworks || [];
 
+      this.config.shippingContactFields = options.shippingContactFields || [];
       this.emit('ready');
     }
   }

--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -92,7 +92,6 @@ class ApplePay extends Emitter {
       merchantCapabilities: this.config.merchantCapabilities,
       requiredBillingContactFields: ['postalAddress'],
       requiredShippingContactFields: this.config.requiredShippingContactFields,
-
       total: this.totalLineItem
     });
 
@@ -204,8 +203,8 @@ class ApplePay extends Emitter {
 
       this.config.merchantCapabilities = info.merchantCapabilities || [];
       this.config.supportedNetworks = info.supportedNetworks || [];
-
       this.config.requiredShippingContactFields = options.requiredShippingContactFields || [];
+      
       this.emit('ready');
     }
   }

--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -299,8 +299,6 @@ class ApplePay extends Emitter {
    */
   onPaymentMethodSelected (event) {
     debug('Payment method selected', event);
-    console.log(event);
-    console.log(this.config.pricing);
     this.session.completePaymentMethodSelection(this.finalTotalLineItem, this.lineItems);
   }
 
@@ -311,26 +309,18 @@ class ApplePay extends Emitter {
    * @private
    */
   onShippingContactSelected (event) {
-    // console.log(event);
     const status = this.session.STATUS_SUCCESS;
 
     var myShippingContact = event.shippingContact;
 
-    // console.log(myShippingContact);
-
     var newTotal = this.finalTotalLineItem;
     var newShippingMethods = [];
     
-    // console.log('this.config.total:');
-    // console.log(this.config.total);
-
     var periodLength = this.config.pricing.items.plan.period.length;
     
     var internationalShippingCost = parseFloat(this.config.pricing.price.addons.shipping);
 
     var basePrice = this.config.pricing.items.plan.price.USD.amount;
-    
-    // var lineItems = this.lineItems;
 
     var internationalShipping = {
       label: "International Shipping", 
@@ -343,9 +333,6 @@ class ApplePay extends Emitter {
     }
 
     if (myShippingContact.countryCode != 'us') {
-      // newShippingMethods = [this.config.internationalShippingMethod];
-      // this.config.total = this.config.total + this.config.internationalShippingMethod.amount;
-
       this.config.total = basePrice + internationalShippingCost;
       this.config.shippingItems = [internationalShipping];
     }
@@ -354,17 +341,8 @@ class ApplePay extends Emitter {
       this.config.total = basePrice;
       this.config.shippingItems = [freeShipping];
     }
-    
-    // console.log('this.finalTotalLineItem:');
-    // console.log(this.finalTotalLineItem);
-    // console.log('this.totalLineItem:');
-    // console.log(this.totalLineItem);
-    // console.log('this.lineItems:');
+
     // console.log(this.lineItems);
-
-    // console.log(this.config.pricing.items.plan.period.length);
-
-    console.log(this.lineItems);
 
     this.session.completeShippingContactSelection(status, newShippingMethods, this.finalTotalLineItem, this.lineItems);
   }
@@ -389,7 +367,6 @@ class ApplePay extends Emitter {
    */
   onPaymentAuthorized (event) {
     debug('Payment authorization received', event);
-    console.log(event);
 
     let data = {};
 
@@ -411,6 +388,9 @@ class ApplePay extends Emitter {
         debug('Token received', token);
 
         this.session.completePayment(this.session.STATUS_SUCCESS);
+        
+        this.emit('authorized', event);
+
         this.emit('token', token);
       }
     });

--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -303,7 +303,7 @@ class ApplePay extends Emitter {
   onShippingContactSelected (event) {
     const status = this.session.STATUS_SUCCESS;
     const newShippingMethods = [];
-console.log(this.lineItems);
+
     this.emit('shippingContactSelected', event);
     
     this.session.completeShippingContactSelection(status, newShippingMethods, this.finalTotalLineItem, this.lineItems);

--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -306,10 +306,9 @@ class ApplePay extends Emitter {
    */
   onShippingContactSelected (event) {
     const status = this.session.STATUS_SUCCESS;
+    const newShippingMethods = [];
 
     this.emit('shippingContactSelected', event);
-
-    var newShippingMethods = [];
     
     this.session.completeShippingContactSelection(status, newShippingMethods, this.finalTotalLineItem, this.lineItems);
   }
@@ -355,9 +354,7 @@ class ApplePay extends Emitter {
         debug('Token received', token);
 
         this.session.completePayment(this.session.STATUS_SUCCESS);
-        
         this.emit('authorized', event);
-
         this.emit('token', token);
       }
     });

--- a/lib/recurly/apple-pay.js
+++ b/lib/recurly/apple-pay.js
@@ -91,7 +91,9 @@ class ApplePay extends Emitter {
       supportedNetworks: this.config.supportedNetworks,
       merchantCapabilities: this.config.merchantCapabilities,
       requiredBillingContactFields: ['postalAddress'],
-      requiredShippingContactFields: this.config.shippingContactFields,
+      requiredShippingContactFields: this.config.requiredShippingContactFields,
+      shippingMethods: this.config.shippingMethods,
+      
       total: this.totalLineItem
     });
 
@@ -110,7 +112,7 @@ class ApplePay extends Emitter {
    */
   get lineItems () {
     // Clone configured line items
-    return [].concat(this.config.lineItems);
+    return [].concat(this.config.lineItems).concat(this.config.shippingItems);
   }
 
   /**
@@ -165,6 +167,9 @@ class ApplePay extends Emitter {
     // Initialize with no line items
     this.config.lineItems = [];
 
+    // Initialize with no shipping items
+    this.config.shippingItems = [];
+
     if ('recurly' in options) this.recurly = options.recurly;
     else return this.initError = this.error('apple-pay-factory-only');
 
@@ -201,7 +206,10 @@ class ApplePay extends Emitter {
       this.config.merchantCapabilities = info.merchantCapabilities || [];
       this.config.supportedNetworks = info.supportedNetworks || [];
 
-      this.config.shippingContactFields = options.shippingContactFields || [];
+      this.config.requiredShippingContactFields = options.requiredShippingContactFields || [];
+      this.config.shippingMethods = options.shippingMethods || [];
+      this.config.freeShippingMethod = options.freeShippingMethod || [];
+      this.config.internationalShippingMethod = options.internationalShippingMethod || [];
       this.emit('ready');
     }
   }
@@ -291,6 +299,8 @@ class ApplePay extends Emitter {
    */
   onPaymentMethodSelected (event) {
     debug('Payment method selected', event);
+    console.log(event);
+    console.log(this.config.pricing);
     this.session.completePaymentMethodSelection(this.finalTotalLineItem, this.lineItems);
   }
 
@@ -301,8 +311,61 @@ class ApplePay extends Emitter {
    * @private
    */
   onShippingContactSelected (event) {
+    // console.log(event);
     const status = this.session.STATUS_SUCCESS;
-    const newShippingMethods = [];
+
+    var myShippingContact = event.shippingContact;
+
+    // console.log(myShippingContact);
+
+    var newTotal = this.finalTotalLineItem;
+    var newShippingMethods = [];
+    
+    // console.log('this.config.total:');
+    // console.log(this.config.total);
+
+    var periodLength = this.config.pricing.items.plan.period.length;
+    
+    var internationalShippingCost = parseFloat(this.config.pricing.price.addons.shipping);
+
+    var basePrice = this.config.pricing.items.plan.price.USD.amount;
+    
+    // var lineItems = this.lineItems;
+
+    var internationalShipping = {
+      label: "International Shipping", 
+      amount: internationalShippingCost
+    }
+
+    var freeShipping = {
+      label: "Free Shipping in USA", 
+      amount: 0.00
+    }
+
+    if (myShippingContact.countryCode != 'us') {
+      // newShippingMethods = [this.config.internationalShippingMethod];
+      // this.config.total = this.config.total + this.config.internationalShippingMethod.amount;
+
+      this.config.total = basePrice + internationalShippingCost;
+      this.config.shippingItems = [internationalShipping];
+    }
+    else {
+      // newShippingMethods = [this.config.freeShippingMethod];
+      this.config.total = basePrice;
+      this.config.shippingItems = [freeShipping];
+    }
+    
+    // console.log('this.finalTotalLineItem:');
+    // console.log(this.finalTotalLineItem);
+    // console.log('this.totalLineItem:');
+    // console.log(this.totalLineItem);
+    // console.log('this.lineItems:');
+    // console.log(this.lineItems);
+
+    // console.log(this.config.pricing.items.plan.period.length);
+
+    console.log(this.lineItems);
+
     this.session.completeShippingContactSelection(status, newShippingMethods, this.finalTotalLineItem, this.lineItems);
   }
 
@@ -326,6 +389,7 @@ class ApplePay extends Emitter {
    */
   onPaymentAuthorized (event) {
     debug('Payment authorization received', event);
+    console.log(event);
 
     let data = {};
 


### PR DESCRIPTION
User can (optionally) request additional fields from Apple Pay, such as email, shipping address, etc, and process the responses on new emitters from `onShippingContactSelected` and `onPaymentAuthorized`.